### PR TITLE
feat: BMP format support

### DIFF
--- a/packages/builder/package.json
+++ b/packages/builder/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.826.0",
     "@aws-sdk/s3-request-presigner": "3.826.0",
+    "@vingle/bmp-js": "^0.2.5",
     "blurhash": "2.0.5",
     "execa": "9.6.0",
     "exif-reader": "2.0.2",

--- a/packages/builder/src/image/processor.ts
+++ b/packages/builder/src/image/processor.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 
+import * as bmp from '@vingle/bmp-js'
 import heicConvert from 'heic-convert'
-import type sharp from 'sharp'
+import sharp from 'sharp'
 
 import { HEIC_FORMATS } from '../constants/index.js'
 import type { Logger } from '../logger/index.js'
@@ -98,4 +99,48 @@ export async function preprocessImageBuffer(
 
   // 其他格式直接返回原始 buffer
   return buffer
+}
+
+// BMP 格式
+const BUF_BMP = Buffer.from([0x42, 0x4d])
+
+export function isBitmap(buf: Buffer): boolean {
+  return Buffer.compare(BUF_BMP, buf.slice(0, 2)) === 0
+}
+
+/**
+ * 将 BMP Buffer 转换为 Sharp 实例
+ * @param bmpBuffer Buffer
+ * @param imageLogger 日志记录器
+ * @returns Sharp 实例
+ */
+export async function convertBmpToJpegSharpInstance(
+  bmpBuffer: Buffer,
+  imageLogger?: Logger['image'],
+): Promise<sharp.Sharp> {
+  const log = imageLogger
+
+  try {
+    log?.info(`开始 BMP → JPEG 转换 (${Math.round(bmpBuffer.length / 1024)}KB)`)
+    const startTime = Date.now()
+
+    // 使用 @vingle/bmp-js 解析 BMP
+    const bmpImage = bmp.decode(bmpBuffer, true)
+    if (!bmpImage) {
+      throw new Error('BMP 解码失败')
+    }
+
+    // 创建 Sharp 实例
+    const sharpInstance = sharp(bmpImage.data, {
+      raw: { width: bmpImage.width, height: bmpImage.height, channels: 4 },
+    }).jpeg()
+
+    const duration = Date.now() - startTime
+    log?.success(`BMP 转换完成 (${duration}ms)`)
+
+    return sharpInstance
+  } catch (error) {
+    log?.error('BMP 转换失败：', error)
+    throw error
+  }
 }

--- a/packages/builder/src/image/processor.ts
+++ b/packages/builder/src/image/processor.ts
@@ -131,8 +131,15 @@ export async function convertBmpToJpegSharpInstance(
     }
 
     // 创建 Sharp 实例
+    // Calculate the number of channels in the BMP image
+    const channels = bmpImage.data.length / (bmpImage.width * bmpImage.height);
+    if (channels !== 3 && channels !== 4) {
+      throw new Error(`Unsupported BMP channel count: ${channels}`);
+    }
+
+    // Create Sharp instance with the correct channel count
     const sharpInstance = sharp(bmpImage.data, {
-      raw: { width: bmpImage.width, height: bmpImage.height, channels: 4 },
+      raw: { width: bmpImage.width, height: bmpImage.height, channels },
     }).jpeg()
 
     const duration = Date.now() - startTime

--- a/packages/builder/src/image/processor.ts
+++ b/packages/builder/src/image/processor.ts
@@ -105,6 +105,9 @@ export async function preprocessImageBuffer(
 const BUF_BMP = Buffer.from([0x42, 0x4d])
 
 export function isBitmap(buf: Buffer): boolean {
+  if (buf.length < 2) {
+    return false
+  }
   return Buffer.compare(BUF_BMP, buf.slice(0, 2)) === 0
 }
 

--- a/packages/builder/src/photo/processor.ts
+++ b/packages/builder/src/photo/processor.ts
@@ -123,10 +123,12 @@ export async function processPhoto(
     // 处理 BMP
     if (isBitmap(imageBuffer)) {
       try {
+        // Convert the BMP image to JPEG format and create a new Sharp instance for the converted image.
         sharpInstance = await convertBmpToJpegSharpInstance(
           imageBuffer,
           workerLoggers.image,
         )
+        // Update the image buffer to reflect the new JPEG data from the Sharp instance.
         imageBuffer = await sharpInstance.toBuffer()
       } catch (error) {
         workerLoggers.image.error(`转换 BMP 失败：${key}`, error)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,6 +338,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: 3.826.0
         version: 3.826.0
+      '@vingle/bmp-js':
+        specifier: ^0.2.5
+        version: 0.2.5
       blurhash:
         specifier: 2.0.5
         version: 2.0.5
@@ -2644,6 +2647,9 @@ packages:
   '@types/node@22.15.31':
     resolution: {integrity: sha512-jnVe5ULKl6tijxUhvQeNbQG/84fHfg+yMak02cT8QVhBx/F05rAVxCGBYYTh2EKz22D6JF5ktXuNwdx7b9iEGw==}
 
+  '@types/node@8.10.66':
+    resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -2944,6 +2950,9 @@ packages:
 
   '@vercel/static-config@3.1.1':
     resolution: {integrity: sha512-IRtKnm9N1Uqd2ayIbLPjRtdwcl1GTWvqF1PuEVNm9O43kmoI+m9VpGlW8oga+5LQq1LmJ2Y67zHr7NbjrH1rrw==}
+
+  '@vingle/bmp-js@0.2.5':
+    resolution: {integrity: sha512-tiY69wMrXgIVcdpkjQybXTyQw+P2rKzUfA6b+biM6BD1utr5QeeEj9fzs0fFHVf+3siTsYwzI6zltV9+i6ehEA==}
 
   '@vitejs/plugin-react@4.5.2':
     resolution: {integrity: sha512-QNVT3/Lxx99nMQWJWF7K4N6apUEuT0KlZA3mx/mVaoGj3smm/8rc8ezz15J1pcbcjDK0V15rpHetVfya08r76Q==}
@@ -9240,6 +9249,8 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@8.10.66': {}
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/parse-author@2.0.3': {}
@@ -9633,6 +9644,10 @@ snapshots:
       ajv: 8.6.3
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
+
+  '@vingle/bmp-js@0.2.5':
+    dependencies:
+      '@types/node': 8.10.66
 
   '@vitejs/plugin-react@4.5.2(vite@6.3.5(@types/node@22.15.31)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.41.0)(tsx@4.19.4)(yaml@2.8.0))':
     dependencies:


### PR DESCRIPTION
## Situation
Some of the film scanner export BMP format image, but now sharp can not handle that format directly.

## Proposal
Add one more step to handle BMP file separately just like what it did to heic/heif files.